### PR TITLE
Sdstor 9205: Add data channel RPC support

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.50.0"
 
 class HomeReplicationConan(ConanFile):
     name = "home_replication"
-    version = "0.0.7"
+    version = "0.0.8"
     homepage = "https://github.com/eBay/HomeReplication"
     description = "Fast Storage Replication using NuRaft"
     topics = ("ebay")

--- a/src/include/home_replication/repl_decls.h
+++ b/src/include/home_replication/repl_decls.h
@@ -7,6 +7,7 @@
 #include <sisl/logging/logging.h>
 #include <iomgr/reactor.hpp>
 #include <homestore/homestore_decl.hpp>
+#include <sisl/fds/buffer.hpp>
 
 SISL_LOGGING_DECL(home_replication)
 
@@ -26,4 +27,9 @@ struct fully_qualified_pba {
     std::string to_key_string() const { return fmt::format("{}_{}", std::to_string(server_id), std::to_string(pba)); }
 };
 using fq_pba_list_t = folly::small_vector< fully_qualified_pba, 4 >;
+
+// data service api names
+static std::string const SEND_DATA{"send_data"};
+static std::string const FETCH_DATA{"fetch_data"};
+
 } // namespace home_replication

--- a/src/include/home_replication/repl_service.h
+++ b/src/include/home_replication/repl_service.h
@@ -35,8 +35,9 @@ class ReplicationService {
 
     std::shared_ptr< nuraft_mesg::consensus_component > m_messaging;
 
-    void on_replica_store_found(uuid_t const uuid, const std::shared_ptr< StateMachineStore >& sm_store,
-                                const std::shared_ptr< nuraft::log_store >& log_store);
+    rs_ptr_t on_replica_store_found(uuid_t const uuid, const std::shared_ptr< StateMachineStore >& sm_store,
+                                    const std::shared_ptr< nuraft::log_store >& log_store);
+
 public:
     ReplicationService(backend_impl_t engine_impl, std::shared_ptr< nuraft_mesg::consensus_component > messaging,
                        on_replica_set_init_t cb);

--- a/src/include/home_replication/repl_set.h
+++ b/src/include/home_replication/repl_set.h
@@ -55,6 +55,21 @@ public:
     /// @return true or false
     bool is_leader();
 
+    /// @brief Register server side implimentation callbacks to data service apis
+    /// @param messaging - messaging service pointer
+    /// @return false indicates error in the data service registration
+    bool register_data_service_apis(std::shared_ptr< nuraft_mesg::consensus_component >& messaging);
+
+    /// @brief Send data to followers
+    /// @param pbas - PBAs to be sent
+    /// @param value - data to be sent
+    void send_in_data_channel(const pba_list_t& pbas, const sisl::sg_list& value);
+
+    /// @brief Send the final responce to the rpc client
+    /// @param outgoing_buf - response buf to client
+    /// @param rpc_data - context provided by the rpc server
+    void send_data_service_response(sisl::io_blob_list_t const& outgoing_buf, void* rpc_data);
+
     std::shared_ptr< nuraft::state_machine > get_state_machine() override;
 
 protected:

--- a/src/include/home_replication/repl_set.h
+++ b/src/include/home_replication/repl_set.h
@@ -70,6 +70,10 @@ public:
     /// @param rpc_data - context provided by the rpc server
     void send_data_service_response(sisl::io_blob_list_t const& outgoing_buf, void* rpc_data);
 
+    /// @brief Fetch pba data from the leader
+    /// @param remote_pbas - list of remote pbas for which data is needed from the leader
+    void fetch_pba_data_from_leader(const pba_list_t& remote_pbas);
+
     std::shared_ptr< nuraft::state_machine > get_state_machine() override;
 
 protected:

--- a/src/include/home_replication/repl_set.h
+++ b/src/include/home_replication/repl_set.h
@@ -65,10 +65,11 @@ public:
     /// @param value - data to be sent
     void send_in_data_channel(const pba_list_t& pbas, const sisl::sg_list& value);
 
-    /// @brief Send the final responce to the rpc client
+    /// @brief Send the final responce to the rpc client. This method is defined virtual for mocking in the gtest
     /// @param outgoing_buf - response buf to client
     /// @param rpc_data - context provided by the rpc server
-    void send_data_service_response(sisl::io_blob_list_t const& outgoing_buf, void* rpc_data);
+    virtual void send_data_service_response(sisl::io_blob_list_t const& outgoing_buf,
+                                            boost::intrusive_ptr< sisl::GenericRpcData >& rpc_data);
 
     /// @brief Fetch pba data from the leader
     /// @param remote_pbas - list of remote pbas for which data is needed from the leader

--- a/src/lib/state_machine/CMakeLists.txt
+++ b/src/lib/state_machine/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(state_machine OBJECT)
 target_sources(state_machine PRIVATE
             state_machine.cpp
             replica_set.cpp
+            rpc_data_channel.cpp
         )
 target_link_libraries(state_machine ${COMMON_DEPS})
 target_compile_features(state_machine PUBLIC cxx_std_17)

--- a/src/lib/state_machine/replica_set.cpp
+++ b/src/lib/state_machine/replica_set.cpp
@@ -49,8 +49,7 @@ bool ReplicaSet::register_data_service_apis(std::shared_ptr< nuraft_mesg::consen
             SEND_DATA, m_group_id,
             [this](sisl::io_blob const& incoming_buf, boost::intrusive_ptr< sisl::GenericRpcData >& rpc_data) {
                 m_state_machine->on_data_received(incoming_buf, rpc_data);
-            },
-            nullptr);
+            });
         !resp) {
         // LOG ERROR
         return false;
@@ -60,9 +59,6 @@ bool ReplicaSet::register_data_service_apis(std::shared_ptr< nuraft_mesg::consen
             FETCH_DATA, m_group_id,
             [this](sisl::io_blob const& incoming_buf, boost::intrusive_ptr< sisl::GenericRpcData >& rpc_data) {
                 m_state_machine->on_fetch_data_request(incoming_buf, rpc_data);
-            },
-            [this](boost::intrusive_ptr< sisl::GenericRpcData >& rpc_data) {
-                m_state_machine->on_fetch_data_completed(rpc_data);
             });
         !resp) {
         // LOG ERROR

--- a/src/lib/state_machine/replica_set.cpp
+++ b/src/lib/state_machine/replica_set.cpp
@@ -7,6 +7,16 @@
 #include "log_store/repl_log_store.hpp"
 #include "log_store/journal_entry.h"
 #include "storage/storage_engine.h"
+#include <boost/uuid/string_generator.hpp>
+
+#if defined __clang__ or defined __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+#include "rpc_data_channel.h"
+#if defined __clang__ or defined __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 namespace home_replication {
 ReplicaSet::ReplicaSet(const std::string& group_id, const std::shared_ptr< StateMachineStore >& sm_store,
@@ -24,16 +34,49 @@ void ReplicaSet::transfer_pba_ownership(int64_t lsn, const pba_list_t& pbas) {
     m_state_store->add_free_pba_record(lsn, pbas);
 }
 
-// void ReplicaSet::on_data_received() {}
-
 std::shared_ptr< nuraft::state_machine > ReplicaSet::get_state_machine() {
     if (!m_state_machine)
         m_state_machine = std::make_shared< ReplicaStateMachine >(m_state_store, this);
     return std::dynamic_pointer_cast< nuraft::state_machine >(m_state_machine);
 }
 
-bool ReplicaSet::is_leader() {
-    // TODO: Need to implement after setting up RAFT replica set
+bool ReplicaSet::is_leader() { return m_repl_svc_ctx->is_raft_leader(); }
+
+void ReplicaSet::send_data_service_response(sisl::io_blob_list_t const& outgoing_buf, void* rpc_data) {
+    m_repl_svc_ctx->send_data_service_response(outgoing_buf, rpc_data);
+}
+
+bool ReplicaSet::register_data_service_apis(std::shared_ptr< nuraft_mesg::consensus_component >& messaging) {
+    if (auto resp = messaging->bind_data_service_request(SEND_DATA, m_group_id,
+                                                         [this](sisl::io_blob const& incoming_buf, void* rpc_data) {
+                                                             m_state_machine->on_data_received(incoming_buf, rpc_data);
+                                                         });
+        !resp) {
+        // LOG ERROR
+        return false;
+    }
+    /*
+    if (auto resp = messaging->bind_data_service_request(FETCH_DATA, m_group_id,
+                                                         [this](sisl::io_blob const& incoming_buf, void* rpc_data) {
+                                                             m_state_machine->on_fetch_data_request(incoming_buf,
+                                                                                                    rpc_data);
+                                                         });
+        !resp) {
+        // LOG ERROR
+        return false;
+    }
+    */
     return true;
 }
+
+void ReplicaSet::send_in_data_channel(const pba_list_t& pbas, const sisl::sg_list& value) {
+    data_channel_rpc_hdr common_header;
+    m_repl_svc_ctx->data_service_request(
+        SEND_DATA,
+        data_rpc::serialize(
+            data_channel_rpc_hdr{boost::uuids::string_generator()(m_group_id), 0 /*replace with replica id*/}, pbas,
+            m_state_store.get(), value),
+        nullptr); // response callback is null as this is fire and forget
+}
+
 } // namespace home_replication

--- a/src/lib/state_machine/replica_set.cpp
+++ b/src/lib/state_machine/replica_set.cpp
@@ -2,6 +2,7 @@
 
 #include <sisl/fds/obj_allocator.hpp>
 #include <sisl/fds/vector_pool.hpp>
+#include <sisl/grpc/generic_service.hpp>
 #include <home_replication/repl_service.h>
 #include "state_machine/state_machine.h"
 #include "log_store/repl_log_store.hpp"
@@ -21,10 +22,7 @@
 namespace home_replication {
 ReplicaSet::ReplicaSet(const std::string& group_id, const std::shared_ptr< StateMachineStore >& sm_store,
                        const std::shared_ptr< nuraft::log_store >& log_store) :
-        m_state_machine{nullptr},
-        m_state_store{sm_store},
-        m_data_journal{log_store},
-        m_group_id{group_id} {}
+        m_state_machine{nullptr}, m_state_store{sm_store}, m_data_journal{log_store}, m_group_id{group_id} {}
 
 void ReplicaSet::write(const sisl::blob& header, const sisl::blob& key, const sisl::sg_list& value, void* user_ctx) {
     m_state_machine->propose(header, key, value, user_ctx);
@@ -35,32 +33,37 @@ void ReplicaSet::transfer_pba_ownership(int64_t lsn, const pba_list_t& pbas) {
 }
 
 std::shared_ptr< nuraft::state_machine > ReplicaSet::get_state_machine() {
-    if (!m_state_machine)
-        m_state_machine = std::make_shared< ReplicaStateMachine >(m_state_store, this);
+    if (!m_state_machine) m_state_machine = std::make_shared< ReplicaStateMachine >(m_state_store, this);
     return std::dynamic_pointer_cast< nuraft::state_machine >(m_state_machine);
 }
 
 bool ReplicaSet::is_leader() { return m_repl_svc_ctx->is_raft_leader(); }
 
-void ReplicaSet::send_data_service_response(sisl::io_blob_list_t const& outgoing_buf, void* rpc_data) {
+void ReplicaSet::send_data_service_response(sisl::io_blob_list_t const& outgoing_buf,
+                                            boost::intrusive_ptr< sisl::GenericRpcData >& rpc_data) {
     m_repl_svc_ctx->send_data_service_response(outgoing_buf, rpc_data);
 }
 
 bool ReplicaSet::register_data_service_apis(std::shared_ptr< nuraft_mesg::consensus_component >& messaging) {
-    if (auto resp = messaging->bind_data_service_request(SEND_DATA, m_group_id,
-                                                         [this](sisl::io_blob const& incoming_buf, void* rpc_data) {
-                                                             m_state_machine->on_data_received(incoming_buf, rpc_data);
-                                                         });
+    if (auto resp = messaging->bind_data_service_request(
+            SEND_DATA, m_group_id,
+            [this](sisl::io_blob const& incoming_buf, boost::intrusive_ptr< sisl::GenericRpcData >& rpc_data) {
+                m_state_machine->on_data_received(incoming_buf, rpc_data);
+            },
+            nullptr);
         !resp) {
         // LOG ERROR
         return false;
     }
 
-    if (auto resp = messaging->bind_data_service_request(FETCH_DATA, m_group_id,
-                                                         [this](sisl::io_blob const& incoming_buf, void* rpc_data) {
-                                                             m_state_machine->on_fetch_data_request(incoming_buf,
-                                                                                                    rpc_data);
-                                                         });
+    if (auto resp = messaging->bind_data_service_request(
+            FETCH_DATA, m_group_id,
+            [this](sisl::io_blob const& incoming_buf, boost::intrusive_ptr< sisl::GenericRpcData >& rpc_data) {
+                m_state_machine->on_fetch_data_request(incoming_buf, rpc_data);
+            },
+            [this](boost::intrusive_ptr< sisl::GenericRpcData >& rpc_data) {
+                m_state_machine->on_fetch_data_completed(rpc_data);
+            });
         !resp) {
         // LOG ERROR
         return false;
@@ -84,7 +87,10 @@ void ReplicaSet::fetch_pba_data_from_leader(const pba_list_t& remote_pbas) {
         data_rpc::serialize(
             data_channel_rpc_hdr{boost::uuids::string_generator()(m_group_id), 0 /*replace with replica id*/},
             remote_pbas, m_state_store.get(), {}),
-        [this](sisl::io_blob const& incoming_buf) { m_state_machine->on_data_received(incoming_buf, nullptr); });
+        [this](sisl::io_blob const& incoming_buf) {
+            auto null_rpc_data = boost::intrusive_ptr< sisl::GenericRpcData >(nullptr);
+            m_state_machine->on_data_received(incoming_buf, null_rpc_data);
+        });
 }
 
 } // namespace home_replication

--- a/src/lib/state_machine/replica_set.cpp
+++ b/src/lib/state_machine/replica_set.cpp
@@ -55,7 +55,7 @@ bool ReplicaSet::register_data_service_apis(std::shared_ptr< nuraft_mesg::consen
         // LOG ERROR
         return false;
     }
-    /*
+    /* TODO add fetch data API
     if (auto resp = messaging->bind_data_service_request(FETCH_DATA, m_group_id,
                                                          [this](sisl::io_blob const& incoming_buf, void* rpc_data) {
                                                              m_state_machine->on_fetch_data_request(incoming_buf,
@@ -70,7 +70,6 @@ bool ReplicaSet::register_data_service_apis(std::shared_ptr< nuraft_mesg::consen
 }
 
 void ReplicaSet::send_in_data_channel(const pba_list_t& pbas, const sisl::sg_list& value) {
-    data_channel_rpc_hdr common_header;
     m_repl_svc_ctx->data_service_request(
         SEND_DATA,
         data_rpc::serialize(

--- a/src/lib/state_machine/replica_set.cpp
+++ b/src/lib/state_machine/replica_set.cpp
@@ -9,15 +9,7 @@
 #include "log_store/journal_entry.h"
 #include "storage/storage_engine.h"
 #include <boost/uuid/string_generator.hpp>
-
-#if defined __clang__ or defined __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
-#endif
-#include "rpc_data_channel.h"
-#if defined __clang__ or defined __GNUC__
-#pragma GCC diagnostic pop
-#endif
+#include "rpc_data_channel_include.h"
 
 namespace home_replication {
 ReplicaSet::ReplicaSet(const std::string& group_id, const std::shared_ptr< StateMachineStore >& sm_store,

--- a/src/lib/state_machine/rpc_data_channel.cpp
+++ b/src/lib/state_machine/rpc_data_channel.cpp
@@ -40,9 +40,11 @@ sisl::io_blob_list_t data_rpc::serialize(const data_channel_rpc_hdr& common_head
     return io_list;
 }
 
-void data_rpc::deserialize(sisl::io_blob const& incoming_buf, fq_pba_list_t& fq_pbas, sisl::sg_list& value) {
+void data_rpc::deserialize(sisl::io_blob const& incoming_buf, data_channel_rpc_hdr& common_header,
+                           fq_pba_list_t& fq_pbas, sisl::sg_list& value) {
     // assert buf.size >= max header size
     data_rpc* rpc = r_cast< data_rpc* >(incoming_buf.bytes);
+    common_header = rpc->common_hdr;
     for (uint16_t i{0}; i < rpc->pba_area[0].n_pbas; ++i) {
         fq_pbas.emplace_back(rpc->common_hdr.issuer_replica_id, rpc->pba_area[0].pinfo[i].pba,
                              rpc->pba_area[0].pinfo[i].data_size);

--- a/src/lib/state_machine/rpc_data_channel.cpp
+++ b/src/lib/state_machine/rpc_data_channel.cpp
@@ -54,4 +54,13 @@ void data_rpc::deserialize(sisl::io_blob const& incoming_buf, data_channel_rpc_h
         iovec{r_cast< void* >(incoming_buf.bytes + data_channel_rpc_hdr::max_hdr_size), value.size});
 }
 
+void data_rpc::deserialize(sisl::io_blob const& incoming_buf, data_channel_rpc_hdr& common_header, pba_list_t& pbas) {
+    // assert buf.size >= max header size
+    data_rpc* rpc = r_cast< data_rpc* >(incoming_buf.bytes);
+    common_header = rpc->common_hdr;
+    for (uint16_t i{0}; i < rpc->pba_area[0].n_pbas; ++i) {
+        pbas.emplace_back(rpc->pba_area[0].pinfo[i].pba);
+    }
+}
+
 } // namespace home_replication

--- a/src/lib/state_machine/rpc_data_channel.cpp
+++ b/src/lib/state_machine/rpc_data_channel.cpp
@@ -1,12 +1,9 @@
 #include "storage/storage_engine.h"
+#include "rpc_data_channel_include.h"
 
 #if defined __clang__ or defined __GNUC__
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
-#endif
-#include "rpc_data_channel.h"
-#if defined __clang__ or defined __GNUC__
-#pragma GCC diagnostic pop
+#pragma GCC diagnostic ignored "-Warray-bounds"
 #endif
 
 namespace home_replication {
@@ -64,3 +61,7 @@ void data_rpc::deserialize(sisl::io_blob const& incoming_buf, data_channel_rpc_h
 }
 
 } // namespace home_replication
+
+#if defined __clang__ or defined __GNUC__
+#pragma GCC diagnostic pop
+#endif

--- a/src/lib/state_machine/rpc_data_channel.cpp
+++ b/src/lib/state_machine/rpc_data_channel.cpp
@@ -1,0 +1,55 @@
+#include "storage/storage_engine.h"
+
+#if defined __clang__ or defined __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+#include "rpc_data_channel.h"
+#if defined __clang__ or defined __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+namespace home_replication {
+
+pbas_serialized* pbas_serialized::serialize(const pba_list_t& pbas, StateMachineStore* store_ptr, uint8_t* raw_ptr) {
+    pbas_serialized* pthis = new (raw_ptr) pbas_serialized();
+    pthis->n_pbas = pbas.size();
+    for (uint16_t i{0}; i < pthis->n_pbas; ++i) {
+        pthis->pinfo[i].pba = pbas[i];
+        pthis->pinfo[i].data_size = store_ptr->pba_to_size(pbas[i]);
+    }
+    return pthis;
+}
+
+sisl::io_blob_list_t data_rpc::serialize(const data_channel_rpc_hdr& common_header, const pba_list_t& pbas,
+                                         StateMachineStore* store_ptr, const sisl::sg_list& value) {
+    if (pbas.size() > max_pbas()) {
+        LOGERROR("Exceeds max number of pbas that can be sent in this rpc");
+        return {};
+    }
+
+    auto* bytes = new uint8_t[data_channel_rpc_hdr::max_hdr_size];
+    data_rpc* rpc = new (bytes) data_rpc();
+
+    rpc->common_hdr = common_header;
+    pbas_serialized::serialize(pbas, store_ptr, uintptr_cast(rpc->pba_area));
+
+    auto io_list = sisl::io_blob::sg_list_to_ioblob_list(value);
+    sisl::io_blob hdr_blob(uintptr_cast(rpc), data_channel_rpc_hdr::max_hdr_size, false);
+    io_list.insert(io_list.begin(), hdr_blob);
+    return io_list;
+}
+
+void data_rpc::deserialize(sisl::io_blob const& incoming_buf, fq_pba_list_t& fq_pbas, sisl::sg_list& value) {
+    // assert buf.size >= max header size
+    data_rpc* rpc = r_cast< data_rpc* >(incoming_buf.bytes);
+    for (uint16_t i{0}; i < rpc->pba_area[0].n_pbas; ++i) {
+        fq_pbas.emplace_back(rpc->common_hdr.issuer_replica_id, rpc->pba_area[0].pinfo[i].pba,
+                             rpc->pba_area[0].pinfo[i].data_size);
+    }
+    value.size = incoming_buf.size - data_channel_rpc_hdr::max_hdr_size;
+    value.iovs.emplace_back(
+        iovec{r_cast< void* >(incoming_buf.bytes + data_channel_rpc_hdr::max_hdr_size), value.size});
+}
+
+} // namespace home_replication

--- a/src/lib/state_machine/rpc_data_channel.h
+++ b/src/lib/state_machine/rpc_data_channel.h
@@ -51,8 +51,11 @@ public:
 
     static sisl::io_blob_list_t serialize(const data_channel_rpc_hdr& common_header, const pba_list_t& pbas,
                                           StateMachineStore* store_ptr, const sisl::sg_list& value);
+
     static void deserialize(sisl::io_blob const& incoming_buf, data_channel_rpc_hdr& common_header,
                             fq_pba_list_t& fq_pbas, sisl::sg_list& value);
+
+    static void deserialize(sisl::io_blob const& incoming_buf, data_channel_rpc_hdr& common_header, pba_list_t& pbas);
 };
 #pragma pack()
 

--- a/src/lib/state_machine/rpc_data_channel.h
+++ b/src/lib/state_machine/rpc_data_channel.h
@@ -51,7 +51,8 @@ public:
 
     static sisl::io_blob_list_t serialize(const data_channel_rpc_hdr& common_header, const pba_list_t& pbas,
                                           StateMachineStore* store_ptr, const sisl::sg_list& value);
-    static void deserialize(sisl::io_blob const& incoming_buf, fq_pba_list_t& fq_pbas, sisl::sg_list& value);
+    static void deserialize(sisl::io_blob const& incoming_buf, data_channel_rpc_hdr& common_header,
+                            fq_pba_list_t& fq_pbas, sisl::sg_list& value);
 };
 #pragma pack()
 

--- a/src/lib/state_machine/rpc_data_channel_include.h
+++ b/src/lib/state_machine/rpc_data_channel_include.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#if defined __clang__ or defined __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+#include "rpc_data_channel.h"
+#if defined __clang__ or defined __GNUC__
+#pragma GCC diagnostic pop
+#endif

--- a/src/lib/state_machine/state_machine.cpp
+++ b/src/lib/state_machine/state_machine.cpp
@@ -25,9 +25,8 @@ SISL_LOGGING_DECL(home_replication)
 
 namespace home_replication {
 
-ReplicaStateMachine::ReplicaStateMachine(const std::shared_ptr< StateMachineStore >& state_store, ReplicaSet* rs,
-                                         const std::string& group_id) :
-        m_state_store{state_store}, m_rs{rs}, m_group_id{group_id} {
+ReplicaStateMachine::ReplicaStateMachine(const std::shared_ptr< StateMachineStore >& state_store, ReplicaSet* rs) :
+        m_state_store{state_store}, m_rs{rs}, m_group_id{rs->m_group_id} {
     m_success_ptr = nuraft::buffer::alloc(sizeof(int));
     m_success_ptr->put(0);
 }
@@ -444,6 +443,10 @@ public:
 
 void ReplicaStateMachine::on_fetch_data_request(sisl::io_blob const& incoming_buf,
                                                 boost::intrusive_ptr< sisl::GenericRpcData >& rpc_data) {
+    // set the completion callback
+    rpc_data->set_comp_cb(
+        [this](boost::intrusive_ptr< sisl::GenericRpcData >& rpc_data) { on_fetch_data_completed(rpc_data); });
+
     // get the pbas for which we need to send the data
     data_channel_rpc_hdr common_header;
     pba_list_t pbas;

--- a/src/lib/state_machine/state_machine.cpp
+++ b/src/lib/state_machine/state_machine.cpp
@@ -333,11 +333,15 @@ void ReplicaStateMachine::create_snapshot(nuraft::snapshot& s, nuraft::async_res
 }
 
 void ReplicaStateMachine::on_data_received(sisl::io_blob const& incoming_buf, void* rpc_data) {
+    data_channel_rpc_hdr common_header;
     sisl::sg_list value;
     fq_pba_list_t fq_pbas;
 
     // deserialize incoming buf and get fq pba list and the data to be written
-    data_rpc::deserialize(incoming_buf, fq_pbas, value);
+    data_rpc::deserialize(incoming_buf, common_header, fq_pbas, value);
+
+    // TODO: sanity checks around common_header
+
     fq_pba_list_t fq_pbas_allocated;
     pba_list_t pbas_final;
     sisl::sg_iterator sg_itr(value.iovs);
@@ -384,6 +388,15 @@ void ReplicaStateMachine::on_data_received(sisl::io_blob const& incoming_buf, vo
     }
 }
 
-// void ReplicaStateMachine::on_fetch_data_request( sisl::io_blob const& incoming_buf, void* rpc_data) {}
+/*
+void ReplicaStateMachine::on_fetch_data_request(sisl::io_blob const& incoming_buf, void* rpc_data) {
+    // get the pbas for which we need to send the data
+    pba_list_t pbas;
+    data_rpc::deserialize(incoming_buf, pbas);
+    for(auto const& pba : pbas) {
+
+    }
+}
+*/
 
 } // namespace home_replication

--- a/src/lib/state_machine/state_machine.cpp
+++ b/src/lib/state_machine/state_machine.cpp
@@ -11,15 +11,7 @@
 #include "storage/storage_engine.h"
 #include "log_store/journal_entry.h"
 #include "service/repl_config.h"
-
-#if defined __clang__ or defined __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
-#endif
-#include "rpc_data_channel.h"
-#if defined __clang__ or defined __GNUC__
-#pragma GCC diagnostic pop
-#endif
+#include "rpc_data_channel_include.h"
 
 SISL_LOGGING_DECL(home_replication)
 

--- a/src/lib/state_machine/state_machine.h
+++ b/src/lib/state_machine/state_machine.h
@@ -164,8 +164,7 @@ using local_pba_info_ptr = std::shared_ptr< local_pba_info >;
 
 class ReplicaStateMachine : public nuraft::state_machine {
 public:
-    ReplicaStateMachine(const std::shared_ptr< StateMachineStore >& state_store, ReplicaSet* rs,
-                        const std::string& group_id);
+    ReplicaStateMachine(const std::shared_ptr< StateMachineStore >& state_store, ReplicaSet* rs);
     ~ReplicaStateMachine() override = default;
     ReplicaStateMachine(ReplicaStateMachine const&) = delete;
     ReplicaStateMachine& operator=(ReplicaStateMachine const&) = delete;

--- a/src/lib/state_machine/state_machine.h
+++ b/src/lib/state_machine/state_machine.h
@@ -248,6 +248,10 @@ public:
     void link_lsn_to_req(repl_req* req, int64_t lsn);
     repl_req* lsn_to_req(int64_t lsn);
 
+    // data service apis
+    void on_data_received(sisl::io_blob const&, void*);
+    // void on_fetch_data_request(sisl::io_blob const&, void*);
+
 private:
     void after_precommit_in_leader(const nuraft::raft_server::req_ext_cb_params& params);
     void check_and_commit(repl_req* req);

--- a/src/lib/state_machine/state_machine.h
+++ b/src/lib/state_machine/state_machine.h
@@ -164,7 +164,8 @@ using local_pba_info_ptr = std::shared_ptr< local_pba_info >;
 
 class ReplicaStateMachine : public nuraft::state_machine {
 public:
-    ReplicaStateMachine(const std::shared_ptr< StateMachineStore >& state_store, ReplicaSet* rs);
+    ReplicaStateMachine(const std::shared_ptr< StateMachineStore >& state_store, ReplicaSet* rs,
+                        const std::string& group_id);
     ~ReplicaStateMachine() override = default;
     ReplicaStateMachine(ReplicaStateMachine const&) = delete;
     ReplicaStateMachine& operator=(ReplicaStateMachine const&) = delete;
@@ -248,9 +249,12 @@ public:
     void link_lsn_to_req(repl_req* req, int64_t lsn);
     repl_req* lsn_to_req(int64_t lsn);
 
-    // data service apis
-    void on_data_received(sisl::io_blob const&, void* rpc_data);
-    void on_fetch_data_request(sisl::io_blob const&, void* rpc_data);
+    // data service apis and helpers
+    void on_data_received(sisl::io_blob const&, boost::intrusive_ptr< sisl::GenericRpcData >& rpc_data);
+    void on_fetch_data_request(sisl::io_blob const&, boost::intrusive_ptr< sisl::GenericRpcData >& rpc_data);
+    void on_fetch_data_completed(boost::intrusive_ptr< sisl::GenericRpcData >& rpc_data);
+    sisl::io_blob_list_t serialize_data_rpc_buf(pba_list_t const& pbas, sisl::sg_list const& value) const;
+    pba_state_t get_pba_state(fully_qualified_pba const& fq_pba) const;
 
 private:
     void after_precommit_in_leader(const nuraft::raft_server::req_ext_cb_params& params);

--- a/src/lib/state_machine/state_machine.h
+++ b/src/lib/state_machine/state_machine.h
@@ -250,7 +250,7 @@ public:
 
     // data service apis
     void on_data_received(sisl::io_blob const&, void* rpc_data);
-    // void on_fetch_data_request(sisl::io_blob const&, void* rpc_data);
+    void on_fetch_data_request(sisl::io_blob const&, void* rpc_data);
 
 private:
     void after_precommit_in_leader(const nuraft::raft_server::req_ext_cb_params& params);

--- a/src/lib/state_machine/state_machine.h
+++ b/src/lib/state_machine/state_machine.h
@@ -249,8 +249,8 @@ public:
     repl_req* lsn_to_req(int64_t lsn);
 
     // data service apis
-    void on_data_received(sisl::io_blob const&, void*);
-    // void on_fetch_data_request(sisl::io_blob const&, void*);
+    void on_data_received(sisl::io_blob const&, void* rpc_data);
+    // void on_fetch_data_request(sisl::io_blob const&, void* rpc_data);
 
 private:
     void after_precommit_in_leader(const nuraft::raft_server::req_ext_cb_params& params);

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -37,3 +37,11 @@ target_link_libraries(test_repl_state_machine
             GTest::gmock)
 add_test(NAME ReplStateMachine COMMAND ${CMAKE_BINARY_DIR}/bin/test_repl_state_machine)
 set_property(TEST ReplStateMachine PROPERTY RUN_SERIAL 1)
+
+add_executable(test_rpc_data_channel)
+target_sources(test_rpc_data_channel PRIVATE test_rpc_data_channel.cpp)
+target_link_libraries(test_rpc_data_channel 
+            home_replication 
+            ${COMMON_TEST_DEPS} 
+            GTest::gmock)
+add_test(NAME RpcDataChannel COMMAND ${CMAKE_BINARY_DIR}/bin/test_rpc_data_channel)

--- a/src/tests/mock_storage_engine.h
+++ b/src/tests/mock_storage_engine.h
@@ -1,0 +1,20 @@
+#include "storage/storage_engine.h"
+
+using namespace home_replication;
+
+class MockStorageEngine : public StateMachineStore {
+public:
+    MOCK_METHOD(pba_list_t, alloc_pbas, (uint32_t), (override));
+    MOCK_METHOD(void, async_write, (const sisl::sg_list&, const pba_list_t&, const io_completion_cb_t&), (override));
+    MOCK_METHOD(void, async_read, (pba_t, sisl::sg_list&, uint32_t, const io_completion_cb_t&), (override));
+    MOCK_METHOD(void, free_pba, (pba_t), (override));
+    MOCK_METHOD(uint32_t, pba_to_size, (pba_t), (override, const));
+    MOCK_METHOD(void, destroy, (), (override));
+    MOCK_METHOD(void, commit_lsn, (repl_lsn_t), (override));
+    MOCK_METHOD(repl_lsn_t, get_last_commit_lsn, (), (override, const));
+    MOCK_METHOD(void, add_free_pba_record, (repl_lsn_t, const pba_list_t&), (override));
+    using get_free_pba_cb = const std::function< void(repl_lsn_t lsn, const pba_list_t& pba) >;
+    MOCK_METHOD(void, get_free_pba_records, (repl_lsn_t, repl_lsn_t, get_free_pba_cb&), (override));
+    MOCK_METHOD(void, remove_free_pba_records_upto, (repl_lsn_t), (override));
+    MOCK_METHOD(void, flush_free_pba_records, (), (override));
+};

--- a/src/tests/mock_storage_engine.h
+++ b/src/tests/mock_storage_engine.h
@@ -1,3 +1,4 @@
+#include <gmock/gmock.h>
 #include "storage/storage_engine.h"
 
 using namespace home_replication;

--- a/src/tests/test_common.h
+++ b/src/tests/test_common.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <gtest/gtest.h>
+#include <random>
+#include "state_machine/rpc_data_channel.h"
+
+static uint64_t get_random_num() {
+    static std::random_device dev;
+    static std::mt19937 rng(dev());
+    std::uniform_int_distribution< std::mt19937::result_type > dist(std::numeric_limits< std::uint64_t >::min(),
+                                                                    std::numeric_limits< std::uint64_t >::max());
+    return dist(rng);
+}
+
+static void generate_data(uint32_t const size, pba_list_t& pbas, std::vector< uint64_t >& data_vec, sisl::sg_list& sgl,
+                          bool const populate_sgl = true) {
+    sgl.size = 0;
+    for (uint32_t i = 0; i < size; ++i) {
+        pbas.emplace_back(get_random_num());
+        data_vec.emplace_back(get_random_num());
+        if (populate_sgl) {
+            sgl.iovs.emplace_back(iovec{new uint64_t(data_vec[i]), sizeof(uint64_t)});
+            sgl.size += sizeof(uint64_t);
+        }
+    }
+}
+
+static sisl::io_blob serialize_to_ioblob(sisl::io_blob_list_t const& ioblob_list) {
+    // allocate a single io_blob which can hold the entire data list above and use this as the rpc incoming buf to
+    // deserialize.
+    uint64_t size = 0;
+    for (auto const& blob : ioblob_list) {
+        size += blob.size;
+    }
+    sisl::io_blob serialized_blob(size);
+    auto offset = serialized_blob.bytes;
+    for (uint16_t i = 0; i < ioblob_list.size(); i++) {
+        std::memcpy(offset, ioblob_list[i].bytes, ioblob_list[i].size);
+        offset += ioblob_list[i].size;
+    }
+
+    return serialized_blob;
+}
+
+static sisl::io_blob serialize_to_ioblob(data_channel_rpc_hdr const& hdr, StateMachineStore* store_ptr,
+                                         pba_list_t const& pbas, sisl::sg_list const& sgl) {
+    auto ioblob_list = data_rpc::serialize(hdr, pbas, store_ptr, sgl);
+    auto ret = serialize_to_ioblob(ioblob_list);
+    // delete the header allocated in data_rpc::serialize above
+    delete[] ioblob_list[0].bytes;
+    return ret;
+}
+
+static void verify_data(sisl::sg_list const& value, std::vector< uint64_t > const& data_vec, bool single_iov) {
+    EXPECT_EQ(value.size, sizeof(uint64_t) * data_vec.size());
+    auto iovec_offset = r_cast< uint8_t* >(value.iovs[0].iov_base);
+    if (single_iov) { EXPECT_EQ(value.iovs.size(), 1); }
+    for (uint32_t i = 0; i < data_vec.size(); i++) {
+        auto rand_num = r_cast< uint64_t* >(iovec_offset);
+        EXPECT_EQ(*rand_num, data_vec[i]);
+        if (i + 1 < data_vec.size()) {
+            iovec_offset =
+                single_iov ? iovec_offset + sizeof(uint64_t) : r_cast< uint8_t* >(value.iovs[i + 1].iov_base);
+        }
+    }
+}
+
+static void free_resources(sisl::sg_list& sgl, sisl::io_blob& serialized_blob) {
+    for (auto& iov : sgl.iovs) {
+        auto data_ptr = r_cast< uint64_t* >(iov.iov_base);
+        delete data_ptr;
+    }
+    serialized_blob.buf_free();
+}

--- a/src/tests/test_rpc_data_channel.cpp
+++ b/src/tests/test_rpc_data_channel.cpp
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <random>
+#include "state_machine/rpc_data_channel.h"
+#include "mock_storage_engine.h"
+#include <boost/uuid/random_generator.hpp>
+
+SISL_LOGGING_INIT(HOMEREPL_LOG_MODS)
+SISL_OPTIONS_ENABLE(logging);
+using namespace home_replication;
+using namespace testing;
+
+static uint64_t get_random_num() {
+    static std::random_device dev;
+    static std::mt19937 rng(dev());
+    std::uniform_int_distribution< std::mt19937::result_type > dist(std::numeric_limits< std::uint64_t >::min(),
+                                                                    std::numeric_limits< std::uint64_t >::max());
+    return dist(rng);
+}
+
+TEST(RpcDataChannel, SerializeAndDeserialize) {
+    using npbas_type = uint16_t;
+    uint16_t test_max_pbas =
+        (data_channel_rpc_hdr::max_hdr_size - sizeof(data_channel_rpc_hdr) - sizeof(pbas_serialized::n_pbas)) /
+        sizeof(pbas_serialized::_pba_info);
+    EXPECT_EQ(data_rpc::max_pbas(), test_max_pbas);
+
+    pba_list_t pbas = {get_random_num(), get_random_num(), get_random_num(), get_random_num()};
+    sisl::sg_list sgl{0, {}};
+    std::vector< uint64_t > data_vec;
+    for (uint16_t i = 0; i < pbas.size(); ++i) {
+        data_vec.emplace_back(get_random_num());
+        sgl.iovs.emplace_back(iovec{new uint64_t(data_vec[i]), sizeof(uint64_t)});
+        sgl.size += sizeof(uint64_t);
+    }
+
+    MockStorageEngine mock_engine;
+    EXPECT_CALL(mock_engine, pba_to_size(_)).Times(pbas.size()).WillRepeatedly([](pba_t const&) {
+        return sizeof(uint64_t);
+    });
+
+    data_channel_rpc_hdr hdr = {boost::uuids::random_generator()(), 1};
+    auto ioblob_list = data_rpc::serialize(hdr, pbas, &mock_engine, sgl);
+}
+
+int main(int argc, char* argv[]) {
+    ::testing::InitGoogleTest(&argc, argv);
+    SISL_OPTIONS_LOAD(argc, argv, logging);
+    sisl::logging::SetLogger("test_home_local_journal");
+    spdlog::set_pattern("[%D %T%z] [%^%l%$] [%t] %v");
+    return RUN_ALL_TESTS();
+}

--- a/src/tests/test_rpc_data_channel.cpp
+++ b/src/tests/test_rpc_data_channel.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#include <gmock/gmock.h>
 #include <random>
 #include "state_machine/rpc_data_channel.h"
 #include "mock_storage_engine.h"
@@ -25,6 +24,7 @@ TEST(RpcDataChannel, SerializeAndDeserialize) {
         sizeof(pbas_serialized::_pba_info);
     EXPECT_EQ(data_rpc::max_pbas(), test_max_pbas);
 
+    // create a list of 4 random pbas and a data vector of 4 random values which represent the data the pbas hold
     pba_list_t pbas = {get_random_num(), get_random_num(), get_random_num(), get_random_num()};
     sisl::sg_list sgl{0, {}};
     std::vector< uint64_t > data_vec;
@@ -34,13 +34,65 @@ TEST(RpcDataChannel, SerializeAndDeserialize) {
         sgl.size += sizeof(uint64_t);
     }
 
+    static constexpr uint32_t mock_engine_size = 1000;
+    static constexpr int32_t svr_id = 5;
+
+    // mock the size storage engine reports for a pba during data_rpc serialize. This is a junk value just for testing
     MockStorageEngine mock_engine;
     EXPECT_CALL(mock_engine, pba_to_size(_)).Times(pbas.size()).WillRepeatedly([](pba_t const&) {
-        return sizeof(uint64_t);
+        return mock_engine_size;
     });
 
-    data_channel_rpc_hdr hdr = {boost::uuids::random_generator()(), 1};
+    // create a hdr with random group id and replica id and serialize hdr, pbas and value into a list of io_blobs
+    data_channel_rpc_hdr hdr = {boost::uuids::random_generator()(), svr_id};
     auto ioblob_list = data_rpc::serialize(hdr, pbas, &mock_engine, sgl);
+
+    // allocate a single io_blob which can hold the entire data list above and use this as the rpc incoming buf to
+    // deserialize.
+    sisl::io_blob serialized_blob(sgl.size + data_channel_rpc_hdr::max_hdr_size);
+    auto offset = serialized_blob.bytes;
+    for (uint16_t i = 0; i < ioblob_list.size(); i++) {
+        std::memcpy(offset, ioblob_list[i].bytes, ioblob_list[i].size);
+        offset += ioblob_list[i].size;
+    }
+
+    // verify the equality of deserialized and serialized values
+    data_channel_rpc_hdr d_hdr;
+    fq_pba_list_t fq_pbas;
+    sisl::sg_list value;
+    data_rpc::deserialize(serialized_blob, d_hdr, fq_pbas, value);
+
+    // common header
+    EXPECT_EQ(hdr.group_id, d_hdr.group_id);
+    EXPECT_EQ(hdr.issuer_replica_id, d_hdr.issuer_replica_id);
+    EXPECT_EQ(hdr.major_version, d_hdr.major_version);
+    EXPECT_EQ(hdr.minor_version, d_hdr.minor_version);
+
+    // pbas
+    EXPECT_EQ(pbas.size(), fq_pbas.size());
+    for (uint16_t i = 0; i < pbas.size(); i++) {
+        EXPECT_EQ(pbas[i], fq_pbas[i].pba);
+        EXPECT_EQ(fq_pbas[i].size, mock_engine_size);
+        EXPECT_EQ(fq_pbas[i].server_id, svr_id);
+    }
+
+    // value
+    EXPECT_EQ(value.size, sizeof(uint64_t) * pbas.size());
+    // We always dump the incoming buf value into a single iovec
+    EXPECT_EQ(value.iovs.size(), 1);
+    auto iovec_offset = r_cast< uint8_t* >(value.iovs[0].iov_base);
+    for (auto const& rn : data_vec) {
+        auto rand_num = r_cast< uint64_t* >(iovec_offset);
+        EXPECT_EQ(*rand_num, rn);
+        iovec_offset += sizeof(uint64_t);
+    }
+
+    // free resources
+    for (auto& iov : sgl.iovs) {
+        auto data_ptr = r_cast< uint64_t* >(iov.iov_base);
+        delete data_ptr;
+    }
+    serialized_blob.buf_free();
 }
 
 int main(int argc, char* argv[]) {

--- a/src/tests/test_rpc_data_channel.cpp
+++ b/src/tests/test_rpc_data_channel.cpp
@@ -1,21 +1,11 @@
-#include <gtest/gtest.h>
-#include <random>
-#include "state_machine/rpc_data_channel.h"
 #include "mock_storage_engine.h"
+#include "test_common.h"
 #include <boost/uuid/random_generator.hpp>
 
 SISL_LOGGING_INIT(HOMEREPL_LOG_MODS)
 SISL_OPTIONS_ENABLE(logging);
 using namespace home_replication;
 using namespace testing;
-
-static uint64_t get_random_num() {
-    static std::random_device dev;
-    static std::mt19937 rng(dev());
-    std::uniform_int_distribution< std::mt19937::result_type > dist(std::numeric_limits< std::uint64_t >::min(),
-                                                                    std::numeric_limits< std::uint64_t >::max());
-    return dist(rng);
-}
 
 TEST(RpcDataChannel, SerializeAndDeserialize) {
     using npbas_type = uint16_t;
@@ -25,14 +15,10 @@ TEST(RpcDataChannel, SerializeAndDeserialize) {
     EXPECT_EQ(data_rpc::max_pbas(), test_max_pbas);
 
     // create a list of 4 random pbas and a data vector of 4 random values which represent the data the pbas hold
-    pba_list_t pbas = {get_random_num(), get_random_num(), get_random_num(), get_random_num()};
-    sisl::sg_list sgl{0, {}};
+    pba_list_t pbas;
+    sisl::sg_list sgl;
     std::vector< uint64_t > data_vec;
-    for (uint16_t i = 0; i < pbas.size(); ++i) {
-        data_vec.emplace_back(get_random_num());
-        sgl.iovs.emplace_back(iovec{new uint64_t(data_vec[i]), sizeof(uint64_t)});
-        sgl.size += sizeof(uint64_t);
-    }
+    generate_data(4, pbas, data_vec, sgl);
 
     static constexpr uint32_t mock_engine_size = 1000;
     static constexpr int32_t svr_id = 5;
@@ -45,16 +31,7 @@ TEST(RpcDataChannel, SerializeAndDeserialize) {
 
     // create a hdr with random group id and replica id and serialize hdr, pbas and value into a list of io_blobs
     data_channel_rpc_hdr hdr = {boost::uuids::random_generator()(), svr_id};
-    auto ioblob_list = data_rpc::serialize(hdr, pbas, &mock_engine, sgl);
-
-    // allocate a single io_blob which can hold the entire data list above and use this as the rpc incoming buf to
-    // deserialize.
-    sisl::io_blob serialized_blob(sgl.size + data_channel_rpc_hdr::max_hdr_size);
-    auto offset = serialized_blob.bytes;
-    for (uint16_t i = 0; i < ioblob_list.size(); i++) {
-        std::memcpy(offset, ioblob_list[i].bytes, ioblob_list[i].size);
-        offset += ioblob_list[i].size;
-    }
+    auto serialized_blob = serialize_to_ioblob(hdr, &mock_engine, pbas, sgl);
 
     // verify the equality of deserialized and serialized values
     data_channel_rpc_hdr d_hdr;
@@ -77,22 +54,9 @@ TEST(RpcDataChannel, SerializeAndDeserialize) {
     }
 
     // value
-    EXPECT_EQ(value.size, sizeof(uint64_t) * pbas.size());
-    // We always dump the incoming buf value into a single iovec
-    EXPECT_EQ(value.iovs.size(), 1);
-    auto iovec_offset = r_cast< uint8_t* >(value.iovs[0].iov_base);
-    for (auto const& rn : data_vec) {
-        auto rand_num = r_cast< uint64_t* >(iovec_offset);
-        EXPECT_EQ(*rand_num, rn);
-        iovec_offset += sizeof(uint64_t);
-    }
+    verify_data(value, data_vec, true);
 
-    // free resources
-    for (auto& iov : sgl.iovs) {
-        auto data_ptr = r_cast< uint64_t* >(iov.iov_base);
-        delete data_ptr;
-    }
-    serialized_blob.buf_free();
+    free_resources(sgl, serialized_blob);
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
The registration of data channel RPCs is done in replica set as it has the access to the consensus component during startup. The implementation to these APIs is mainly handled by the state machine. data_rpc class is used for serializing and deserializing the common header (raft group info, versions etc) and the pba info.