### PR TITLE
add user ctx to ReplicaSet append_entry interface

### DIFF
--- a/src/include/home_replication/repl_set.h
+++ b/src/include/home_replication/repl_set.h
@@ -108,7 +108,8 @@ public:
     /// @brief Append an application/user specific message to the journal.
     ///
     /// @param buffer - Opaque buffer to be interpreted by the user
-    virtual void append_entry(nuraft::buffer const& b) = 0;
+    /// @user_ctx - User supplied opaque context which will be passed to listener callbacks 
+    virtual void append_entry(nuraft::buffer const& b, void* user_ctx) = 0;
 
     /// @brief Checks if this replica is the leader in this replica set
     /// @return true or false

--- a/src/lib/state_machine/repl_set_impl.h
+++ b/src/lib/state_machine/repl_set_impl.h
@@ -47,7 +47,7 @@ public:
 
     std::shared_ptr< nuraft::state_machine > get_state_machine() override;
 
-    void append_entry(nuraft::buffer const&) override {}
+    void append_entry(nuraft::buffer const&, void*) override {}
 
     std::string group_id() const override { return m_group_id; }
 

--- a/src/mocks/repl_service.cpp
+++ b/src/mocks/repl_service.cpp
@@ -34,7 +34,7 @@ public:
     void transfer_pba_ownership(int64_t, const pba_list_t&) override {}
     void send_data_service_response(sisl::io_blob_list_t const&,
                                     boost::intrusive_ptr< sisl::GenericRpcData >&) override {}
-    void append_entry(nuraft::buffer const&) override {}
+    void append_entry(nuraft::buffer const&, void*) override {}
     bool is_leader() const override { return true; }
     std::string group_id() const override { return _g_id; }
 


### PR DESCRIPTION
we need a way to let the append_entry() caller to know when user message is commited in raft state_machine, likely write() does, the newly added user_ctx will be passed to raft state_machine when this message is commited and give caller a chance to know this event.